### PR TITLE
consolidate io_uring_cmd backend fix

### DIFF
--- a/src/include/io_engines/nvme_async_io_engine.hpp
+++ b/src/include/io_engines/nvme_async_io_engine.hpp
@@ -2,6 +2,9 @@
 
 #include "nvme_io_engine.hpp"
 #include "nvme_device.hpp"
+#include <chrono>
+#include <future>
+#include <vector>
 
 namespace duckdb {
 
@@ -10,14 +13,26 @@ public:
 	using NvmeIOEngine::NvmeIOEngine;
 
 	void Read(void *buffer, const NvmeCmdContext &ctx) override {
-		// Allocate based on LBA size (aligned), not user request size
-		// Using nr_bytes causes buffer overflow if it is smaller than the full LBA size
-		idx_t alloc_size = ctx.nr_lbas * device.geometry.lba_size;
-		nvme_buf_ptr dev_buffer = device.AllocateDeviceBuffer(alloc_size);
-
 		uint32_t nsid = xnvme_dev_get_nsid(device.device);
-		uint8_t plid_idx = device.GetPlacementIdentifierOrDefault(ctx.filepath);
+		idx_t alloc_size = ctx.nr_lbas * device.geometry.lba_size;
 
+		void *dev_buffer = device.AllocateDeviceBuffer(alloc_size);
+		if (!dev_buffer) {
+			throw IOException("Failed to allocate NVMe DMA buffer");
+		}
+
+		// Calculate MDTS/4K-clamped chunk size to stay within controller limits
+		const xnvme_geo *geo = xnvme_dev_get_geo(device.device);
+		uint32_t max_lbas = geo->mdts_nbytes > 0 ? geo->mdts_nbytes / device.geometry.lba_size : 127;
+		uint32_t lbas_per_4k = 4096 / device.geometry.lba_size;
+		if (lbas_per_4k > 0) {
+			max_lbas = (max_lbas / lbas_per_4k) * lbas_per_4k;
+		}
+		if (max_lbas == 0) {
+			max_lbas = lbas_per_4k;
+		}
+
+		uint8_t plid_idx = device.GetPlacementIdentifierOrDefault(ctx.filepath);
 		idx_t thread_index = device.GetThreadIndex();
 		xnvme_queue *queue = device.queues[thread_index];
 
@@ -31,59 +46,95 @@ public:
 			queue = device.queues[thread_index];
 		}
 
-		xnvme_cmd_ctx *xnvme_ctx = xnvme_queue_get_cmd_ctx(queue);
-		device.PrepareIOCmdContext(xnvme_ctx, ctx, plid_idx, 0, false);
+		uint32_t lbas_left = ctx.nr_lbas;
+		uint64_t slba = ctx.start_lba;
+		uint32_t buf_offset = 0;
 
-		std::promise<void> cb_notify;
-		std::future<void> fut = cb_notify.get_future();
-
-		xnvme_cmd_ctx_set_cb(xnvme_ctx, device.CommandCallback, &cb_notify);
-
-		std::future_status status;
-		std::chrono::milliseconds interval = std::chrono::milliseconds(0);
-
-		int err = xnvme_nvm_read(xnvme_ctx, nsid, ctx.start_lba, ctx.nr_lbas - 1, dev_buffer, nullptr);
-		if (err) {
-			device.FreeDeviceBuffer(dev_buffer, alloc_size);
-			xnvme_cli_perr("Could not submit command to queue with xnvme_nvme_read(): ", err);
-			throw IOException("Encountered error when reading from NVMe device");
+		size_t num_chunks = (ctx.nr_lbas + max_lbas - 1) / max_lbas;
+		std::vector<std::promise<void>> promises(num_chunks);
+		std::vector<std::future<void>> futures;
+		futures.reserve(num_chunks);
+		for (auto &p : promises) {
+			futures.push_back(p.get_future());
 		}
 
-		do {
-			xnvme_queue_poke(queue, 0);
-			status = fut.wait_for(interval);
-		} while (status != std::future_status::ready);
+		size_t chunk_idx = 0;
+		while (lbas_left > 0) {
+			uint32_t chunk = std::min(lbas_left, max_lbas);
+
+			xnvme_cmd_ctx *xnvme_ctx = xnvme_queue_get_cmd_ctx(queue);
+			device.PrepareIOCmdContext(xnvme_ctx, ctx, plid_idx, 0, false);
+			xnvme_cmd_ctx_set_cb(xnvme_ctx, device.CommandCallback, &promises[chunk_idx]);
+
+			int err = xnvme_nvm_read(xnvme_ctx, nsid, slba, chunk - 1, (char *)dev_buffer + buf_offset, nullptr);
+			if (err) {
+				device.FreeDeviceBuffer(dev_buffer, alloc_size);
+				xnvme_cli_perr("Could not submit command to queue with xnvme_nvme_read(): ", err);
+				throw IOException("Encountered error when reading from NVMe device");
+			}
+
+			lbas_left -= chunk;
+			slba += chunk;
+			buf_offset += (chunk * device.geometry.lba_size);
+			chunk_idx++;
+		}
+
+		std::chrono::milliseconds interval = std::chrono::milliseconds(0);
+		for (auto &fut : futures) {
+			std::future_status status;
+			do {
+				xnvme_queue_poke(queue, 0);
+				status = fut.wait_for(interval);
+			} while (status != std::future_status::ready);
+		}
 
 		memcpy(buffer, (char *)dev_buffer + ctx.offset, ctx.nr_bytes);
-
 		device.FreeDeviceBuffer(dev_buffer, alloc_size);
 	}
 
 	void Write(void *buffer, const NvmeCmdContext &ctx) override {
-		//  Allocate based on LBA size
+		uint32_t nsid = xnvme_dev_get_nsid(device.device);
 		idx_t alloc_size = ctx.nr_lbas * device.geometry.lba_size;
-		nvme_buf_ptr dev_buffer = device.AllocateDeviceBuffer(alloc_size);
 
-		// Read-Modify-Write logic for partial blocks (Copied from synchronous Write)
-		if (ctx.offset > 0 || ctx.nr_bytes < alloc_size) {
-			uint32_t nsid = xnvme_dev_get_nsid(device.device);
-			xnvme_cmd_ctx read_ctx = xnvme_cmd_ctx_from_dev(device.device);
-			read_ctx.cmd.common.cdw12 = ctx.nr_lbas - 1;
+		void *dev_buffer = device.AllocateDeviceBuffer(alloc_size);
+		if (!dev_buffer) {
+			throw IOException("Failed to allocate NVMe DMA buffer");
+		}
 
-			// We do a synchronous read here to ensure the buffer is populated before we modify it
-			int err = xnvme_nvm_read(&read_ctx, nsid, ctx.start_lba, ctx.nr_lbas - 1, dev_buffer, nullptr);
-			if (err) {
-				device.FreeDeviceBuffer(dev_buffer, alloc_size);
-				throw IOException("Read-modify-write failed in WriteAsync");
+		const xnvme_geo *geo = xnvme_dev_get_geo(device.device);
+		uint32_t max_lbas = geo->mdts_nbytes > 0 ? geo->mdts_nbytes / device.geometry.lba_size : 127;
+		uint32_t lbas_per_4k = 4096 / device.geometry.lba_size;
+		if (lbas_per_4k > 0) {
+			max_lbas = (max_lbas / lbas_per_4k) * lbas_per_4k;
+		}
+		if (max_lbas == 0) {
+			max_lbas = lbas_per_4k;
+		}
+
+		bool needs_rmw = ctx.offset > 0 || ctx.nr_bytes < alloc_size;
+		if (needs_rmw) {
+			uint32_t lbas_left = ctx.nr_lbas;
+			uint64_t slba = ctx.start_lba;
+			uint32_t buf_offset = 0;
+
+			while (lbas_left > 0) {
+				uint32_t chunk = std::min(lbas_left, max_lbas);
+				xnvme_cmd_ctx sync_ctx = xnvme_cmd_ctx_from_dev(device.device);
+
+				int err = xnvme_nvm_read(&sync_ctx, nsid, slba, chunk - 1, (char *)dev_buffer + buf_offset, nullptr);
+				if (err) {
+					device.FreeDeviceBuffer(dev_buffer, alloc_size);
+					throw IOException("Read-modify-write chunk failed");
+				}
+				lbas_left -= chunk;
+				slba += chunk;
+				buf_offset += (chunk * device.geometry.lba_size);
 			}
 		}
 
-		// Copy user data to the aligned buffer at the correct offset
 		memcpy((char *)dev_buffer + ctx.offset, buffer, ctx.nr_bytes);
 
-		uint32_t nsid = xnvme_dev_get_nsid(device.device);
 		uint8_t plid_idx = device.GetPlacementIdentifierOrDefault(ctx.filepath);
-
 		idx_t thread_index = device.GetThreadIndex();
 		xnvme_queue *queue = device.queues[thread_index];
 
@@ -97,28 +148,47 @@ public:
 			queue = device.queues[thread_index];
 		}
 
-		xnvme_cmd_ctx *xnvme_ctx = xnvme_queue_get_cmd_ctx(queue);
-		device.PrepareIOCmdContext(xnvme_ctx, ctx, plid_idx, DATA_PLACEMENT_MODE, true);
+		uint32_t lbas_left = ctx.nr_lbas;
+		uint64_t slba = ctx.start_lba;
+		uint32_t buf_offset = 0;
 
-		std::promise<void> cb_notify;
-		std::future<void> fut = cb_notify.get_future();
-
-		xnvme_cmd_ctx_set_cb(xnvme_ctx, device.CommandCallback, &cb_notify);
-
-		std::future_status status;
-		std::chrono::milliseconds interval = std::chrono::milliseconds(0);
-
-		int err = xnvme_nvm_write(xnvme_ctx, nsid, ctx.start_lba, ctx.nr_lbas - 1, dev_buffer, nullptr);
-		if (err) {
-			device.FreeDeviceBuffer(dev_buffer, alloc_size);
-			xnvme_cli_perr("Could not submit command to queue with xnvme_nvme_write(): ", err);
-			throw IOException("Encountered error when writing to NVMe device");
+		size_t num_chunks = (ctx.nr_lbas + max_lbas - 1) / max_lbas;
+		std::vector<std::promise<void>> promises(num_chunks);
+		std::vector<std::future<void>> futures;
+		futures.reserve(num_chunks);
+		for (auto &p : promises) {
+			futures.push_back(p.get_future());
 		}
 
-		do {
-			xnvme_queue_poke(queue, 0);
-			status = fut.wait_for(interval);
-		} while (status != std::future_status::ready);
+		size_t chunk_idx = 0;
+		while (lbas_left > 0) {
+			uint32_t chunk = std::min(lbas_left, max_lbas);
+
+			xnvme_cmd_ctx *xnvme_ctx = xnvme_queue_get_cmd_ctx(queue);
+			device.PrepareIOCmdContext(xnvme_ctx, ctx, plid_idx, DATA_PLACEMENT_MODE, true);
+			xnvme_cmd_ctx_set_cb(xnvme_ctx, device.CommandCallback, &promises[chunk_idx]);
+
+			int err = xnvme_nvm_write(xnvme_ctx, nsid, slba, chunk - 1, (char *)dev_buffer + buf_offset, nullptr);
+			if (err) {
+				device.FreeDeviceBuffer(dev_buffer, alloc_size);
+				xnvme_cli_perr("Could not submit command to queue with xnvme_nvme_write(): ", err);
+				throw IOException("Encountered error when writing to NVMe device");
+			}
+
+			lbas_left -= chunk;
+			slba += chunk;
+			buf_offset += (chunk * device.geometry.lba_size);
+			chunk_idx++;
+		}
+
+		std::chrono::milliseconds interval = std::chrono::milliseconds(0);
+		for (auto &fut : futures) {
+			std::future_status status;
+			do {
+				xnvme_queue_poke(queue, 0);
+				status = fut.wait_for(interval);
+			} while (status != std::future_status::ready);
+		}
 
 		device.FreeDeviceBuffer(dev_buffer, alloc_size);
 	}

--- a/src/nvmefs_config.cpp
+++ b/src/nvmefs_config.cpp
@@ -52,9 +52,6 @@ void CreateNvmefsSecretFunctions::Register(DatabaseInstance &instance) {
 NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 	DBConfig &config = DBConfig::GetConfig(instance);
 
-	// Change global settings
-	TempDirectorySetting::SetGlobal(&instance, config, Value("nvmefs:///tmp"));
-
 	KeyValueSecretReader secret_reader(instance, "nvmefs", "nvmefs://");
 
 	string device;
@@ -80,6 +77,10 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 	                          Value(meta));
 
 	backend = SanatizeBackend(backend);
+
+	if (!device.empty()) {
+		TempDirectorySetting::SetGlobal(&instance, config, Value("nvmefs:///tmp"));
+	}
 
 	return NvmeConfig {
 	    .device_path = device,


### PR DESCRIPTION
The async IO engine now respects the NVMe controller's Maximum Data Transfer Size (MDTS) limit, fixing errors with the io_uring_cmd backend. Large reads and writes are split into MDTS-compliant chunks, each submitted asynchronously and tracked with futures until completion. The same chunking logic applies to read-modify-write operations for partial block writes, ensuring all transfers stay within the controller's size constraints.

Also fix the extension initialization, so it will not overwrite the temporary file directory path, if the secret is not defined.