### PR TITLE
feat: add fdp mapping secret and metrics for spill and WAL

### DIFF
--- a/scripts/nvme/device_dealloc.sh
+++ b/scripts/nvme/device_dealloc.sh
@@ -1,29 +1,38 @@
 #!/bin/bash
 
-DEV=${1:-/dev/nvme1}
+DEV=${1:-/dev/nvme0}
 NSID=${2:-1}
 
 echo "Using:"
 echo "  Device: $DEV"
 echo "  Namespace ID: $NSID"
 
-# Check device exists
 if [ ! -e "$DEV" ]; then
     echo "Error: Device $DEV does not exist"
     exit 1
 fi
 
 # Get the namespace size in blocks
-NSZE=$(sudo nvme id-ns $DEV -n $NSID 2>/dev/null | grep "nsze" | awk '{print $3}')
+NSZE=$(nvme id-ns $DEV -n $NSID 2>/dev/null | grep "nsze" | awk '{print $3}')
 
 if [ -z "$NSZE" ]; then
     echo "Error: Could not get namespace size for namespace $NSID on $DEV"
     exit 1
 fi
 
-echo "Deallocating $NSZE blocks on ${DEV}n${NSID}"
+nvme list
+echo "About to deallocate $NSZE blocks on ${DEV}n${NSID}"
+read -r -p "Are you sure you want to continue? [y/N] " CONFIRM
+
+case "$CONFIRM" in
+    [yY])
+        ;;
+    *)
+        echo "Aborted"
+        exit 0
+        ;;
+esac
 
 # Deallocate all blocks (trim/discard)
-sudo nvme dsm ${DEV}n${NSID} --namespace-id=$NSID --ad -s 0 -b $NSZE
-
+nvme dsm ${DEV}n${NSID} --namespace-id=$NSID --ad -s 0 -b $NSZE
 echo "Deallocation complete"

--- a/src/include/nvmefs_config.hpp
+++ b/src/include/nvmefs_config.hpp
@@ -21,6 +21,7 @@ struct NvmeConfig {
 	uint64_t max_temp_size;
 	uint64_t max_wal_size;
 	uint64_t max_threads;
+	std::unordered_map<string, uint8_t> fdp_mapping;
 };
 
 class NvmeConfigManager {

--- a/src/nvme_device.cpp
+++ b/src/nvme_device.cpp
@@ -53,7 +53,8 @@ NvmeDevice::NvmeDevice(const NvmeConfig &config)
 	}
 
 	GetThreadIndex();
-	allocated_placement_identifiers["nvmefs:///tmp"] = 1;
+
+	allocated_placement_identifiers = config.fdp_mapping;
 	geometry = LoadDeviceGeometry();
 }
 
@@ -70,14 +71,29 @@ DeviceGeometry NvmeDevice::GetDeviceGeometry() {
 }
 
 uint8_t NvmeDevice::GetPlacementIdentifierOrDefault(const string &path) {
-	uint8_t placement_identifier = 0;
-	for (const auto &kv : allocated_placement_identifiers) {
-		if (StringUtil::StartsWith(path, kv.first)) {
-			placement_identifier = kv.second;
-		}
-	}
+	// Isolate the filename 
+    string filename = path;
+    auto last_slash = path.find_last_of('/');
+    if (last_slash != string::npos) {
+        filename = path.substr(last_slash + 1);
+    }
 
-	return placement_identifier;
+    // Exact matches for filenames
+    for (const auto &kv : allocated_placement_identifiers) {
+        if (!StringUtil::StartsWith(kv.first, ".") && filename == kv.first) {
+            return kv.second;
+        }
+    }
+
+    // Target matches for file extension
+    for (const auto &kv : allocated_placement_identifiers) {
+        if (StringUtil::StartsWith(kv.first, ".") && StringUtil::Contains(path, kv.first)) {
+            return kv.second;
+        }
+    }
+
+    // Default fallback RUH
+    return 0;
 }
 
 nvme_buf_ptr NvmeDevice::AllocateDeviceBuffer(idx_t nr_bytes) {

--- a/src/nvme_device.cpp
+++ b/src/nvme_device.cpp
@@ -54,7 +54,7 @@ NvmeDevice::NvmeDevice(const NvmeConfig &config)
 
 	GetThreadIndex();
 
-	allocated_placement_identifiers = config.fdp_mapping;
+	allocated_placement_identifiers = std::map<string, uint8_t>(config.fdp_mapping.begin(), config.fdp_mapping.end());
 	geometry = LoadDeviceGeometry();
 }
 
@@ -71,29 +71,29 @@ DeviceGeometry NvmeDevice::GetDeviceGeometry() {
 }
 
 uint8_t NvmeDevice::GetPlacementIdentifierOrDefault(const string &path) {
-	// Isolate the filename 
-    string filename = path;
-    auto last_slash = path.find_last_of('/');
-    if (last_slash != string::npos) {
-        filename = path.substr(last_slash + 1);
-    }
+	// Isolate the filename
+	string filename = path;
+	auto last_slash = path.find_last_of('/');
+	if (last_slash != string::npos) {
+		filename = path.substr(last_slash + 1);
+	}
 
-    // Exact matches for filenames
-    for (const auto &kv : allocated_placement_identifiers) {
-        if (!StringUtil::StartsWith(kv.first, ".") && filename == kv.first) {
-            return kv.second;
-        }
-    }
+	// Exact matches for filenames
+	for (const auto &kv : allocated_placement_identifiers) {
+		if (!StringUtil::StartsWith(kv.first, ".") && filename == kv.first) {
+			return kv.second;
+		}
+	}
 
-    // Target matches for file extension
-    for (const auto &kv : allocated_placement_identifiers) {
-        if (StringUtil::StartsWith(kv.first, ".") && StringUtil::Contains(path, kv.first)) {
-            return kv.second;
-        }
-    }
+	// Target matches for file extension
+	for (const auto &kv : allocated_placement_identifiers) {
+		if (StringUtil::StartsWith(kv.first, ".") && StringUtil::Contains(path, kv.first)) {
+			return kv.second;
+		}
+	}
 
-    // Default fallback RUH
-    return 0;
+	// Default fallback RUH
+	return 0;
 }
 
 nvme_buf_ptr NvmeDevice::AllocateDeviceBuffer(idx_t nr_bytes) {

--- a/src/nvme_device.cpp
+++ b/src/nvme_device.cpp
@@ -71,29 +71,15 @@ DeviceGeometry NvmeDevice::GetDeviceGeometry() {
 }
 
 uint8_t NvmeDevice::GetPlacementIdentifierOrDefault(const string &path) {
-	// Isolate the filename
-	string filename = path;
-	auto last_slash = path.find_last_of('/');
-	if (last_slash != string::npos) {
-		filename = path.substr(last_slash + 1);
-	}
+    for (const auto &entry : allocated_placement_identifiers) {
+        // Check if the file path ends with the extension defined in the key
+        if (StringUtil::EndsWith(path, entry.first)) {
+            return entry.second;
+        }
+    }
 
-	// Exact matches for filenames
-	for (const auto &kv : allocated_placement_identifiers) {
-		if (!StringUtil::StartsWith(kv.first, ".") && filename == kv.first) {
-			return kv.second;
-		}
-	}
-
-	// Target matches for file extension
-	for (const auto &kv : allocated_placement_identifiers) {
-		if (StringUtil::StartsWith(kv.first, ".") && StringUtil::Contains(path, kv.first)) {
-			return kv.second;
-		}
-	}
-
-	// Default fallback RUH
-	return 0;
+    // Default fallback RUH
+    return 0;
 }
 
 nvme_buf_ptr NvmeDevice::AllocateDeviceBuffer(idx_t nr_bytes) {
@@ -176,6 +162,9 @@ void NvmeDevice::PrepareIOCmdContext(xnvme_cmd_ctx *ctx, const CmdContext &cmd_c
 	if (write && fdp) {
 		ctx->cmd.common.cdw12 |= dtype << 20;
 
+		if (plid_idx >= placement_handlers.size()) {
+			plid_idx = 0; // Fallback to default
+		}
 		uint16_t phid = placement_handlers[plid_idx];
 		ctx->cmd.common.cdw13 = phid << 16;
 	}

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -1,5 +1,6 @@
 #include "nvmefs.hpp"
 #include "strategies/file_strategy_factory.hpp"
+#include <atomic>
 
 namespace duckdb {
 
@@ -26,6 +27,12 @@ void NvmeFileHandle::Sync() {
 
 void NvmeFileHandle::Close() {
 }
+
+std::atomic<uint64_t> nvmefs_current_wal_bytes {0};
+std::atomic<uint64_t> nvmefs_peak_wal_bytes {0};
+
+std::atomic<uint64_t> nvmefs_total_spill_bytes {0};
+std::atomic<uint64_t> nvmefs_total_wal_bytes {0};
 
 unique_ptr<CmdContext> NvmeFileHandle::PrepareCommand(idx_t nr_bytes, idx_t start_lba, idx_t offset) {
 	unique_ptr<NvmeCmdContext> nvme_cmd_ctx = make_uniq<NvmeCmdContext>();
@@ -136,7 +143,7 @@ void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 
 	FileMetadataStrategy *strategy = fh.GetStrategy();
 
-	idx_t start_lba = strategy->GetLBA(fh.path, nr_bytes, location, nr_lbas, geo);
+	idx_t start_lba = strategy->GetLBA(fh.GetPath(), nr_bytes, location, nr_lbas, geo);
 	idx_t in_block_offset = location % geo.lba_size;
 	unique_ptr<CmdContext> cmd_ctx = fh.PrepareCommand(nr_bytes, start_lba, in_block_offset);
 
@@ -146,6 +153,23 @@ void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 
 	device->Write(buffer, *cmd_ctx);
 	strategy->UpdateMetadata(*cmd_ctx);
+
+	NvmeFileType file_type = NvmePathHandler::GetFileType(fh.GetPath());
+
+	if (file_type == NvmeFileType::TEMPORARY) {
+		nvmefs_total_spill_bytes += nr_bytes;
+	} else if (file_type == NvmeFileType::WAL) {
+		nvmefs_total_wal_bytes += nr_bytes;
+
+		// Get absolute truth from the strategy
+		uint64_t true_size = GetFileSize(handle);
+		nvmefs_current_wal_bytes.store(true_size);
+
+		// Update Peak
+		uint64_t peak = nvmefs_peak_wal_bytes.load();
+		while (true_size > peak && !nvmefs_peak_wal_bytes.compare_exchange_weak(peak, true_size)) {
+		}
+	}
 }
 
 int64_t NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
@@ -179,7 +203,7 @@ int64_t NvmeFileSystem::GetFileSize(FileHandle &handle) {
 
 	FileMetadataStrategy *strategy = fh.GetStrategy();
 
-	idx_t nr_lbas = strategy->GetFileSizeLBA(fh.path);
+	idx_t nr_lbas = strategy->GetFileSizeLBA(fh.GetPath());
 	return nr_lbas * geo.lba_size;
 }
 
@@ -201,6 +225,12 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 
 	FileMetadataStrategy *strategy = nvme_handle.GetStrategy();
 	strategy->Truncate(nvme_handle.path, new_size);
+
+	NvmeFileType file_type = NvmePathHandler::GetFileType(nvme_handle.GetPath());
+
+	if (file_type == NvmeFileType::WAL) {
+		nvmefs_current_wal_bytes.store(new_size);
+	}
 }
 
 bool NvmeFileSystem::DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) {

--- a/src/nvmefs_config.cpp
+++ b/src/nvmefs_config.cpp
@@ -28,6 +28,7 @@ void SetNvmefsSecretParameters(CreateSecretFunction &function) {
 	function.named_parameters["nvme_device_path"] = LogicalType::VARCHAR;
 	function.named_parameters["backend"] = LogicalType::VARCHAR;
 	function.named_parameters["meta"] = LogicalType::VARCHAR;
+	function.named_parameters["fdp_mapping"] = LogicalType::VARCHAR;
 }
 
 void RegisterCreateNvmefsSecretFunciton(DatabaseInstance &instance) {
@@ -57,7 +58,7 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 	string device;
 	string backend;
 	string meta;
-	string fdp_mapping_str = ".db:0,.wal:1,.tmp:2";
+	string fdp_mapping_str;
 
 	// TODO: ensure that we always have value here. It is possible to not have value
 	idx_t max_temp_size = 200ULL << 30; // 200 GiB
@@ -71,6 +72,7 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 	secret_reader.TryGetSecretKeyOrSetting<string>("nvme_device_path", "nvme_device_path", device);
 	secret_reader.TryGetSecretKeyOrSetting<string>("backend", "backend", backend);
 	secret_reader.TryGetSecretKeyOrSetting<string>("meta", "meta", meta);
+	secret_reader.TryGetSecretKeyOrSetting<string>("fdp_mapping", "fdp_mapping", fdp_mapping_str);
 
 	config.AddExtensionOption("nvme_device_path", "Path to NVMe device", {LogicalType::VARCHAR}, Value(device));
 	config.AddExtensionOption("backend", "xnvme backend used for IO", {LogicalType::VARCHAR}, Value(backend));

--- a/src/nvmefs_config.cpp
+++ b/src/nvmefs_config.cpp
@@ -57,6 +57,7 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 	string device;
 	string backend;
 	string meta;
+	string fdp_mapping_str = ".db:0,.wal:1,.tmp:2";
 
 	// TODO: ensure that we always have value here. It is possible to not have value
 	idx_t max_temp_size = 200ULL << 30; // 200 GiB
@@ -75,6 +76,7 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 	config.AddExtensionOption("backend", "xnvme backend used for IO", {LogicalType::VARCHAR}, Value(backend));
 	config.AddExtensionOption("meta", "Whether to print additional metadata about the device", {LogicalType::VARCHAR},
 	                          Value(meta));
+	config.AddExtensionOption("fdp_mapping", "FDP mapping", {LogicalType::VARCHAR}, Value(fdp_mapping_str));
 
 	backend = SanatizeBackend(backend);
 
@@ -82,14 +84,23 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 		TempDirectorySetting::SetGlobal(&instance, config, Value("nvmefs:///tmp"));
 	}
 
-	return NvmeConfig {
-	    .device_path = device,
-	    .backend = backend,
-	    .meta = meta,
-	    .max_temp_size = max_temp_size,
-	    .max_wal_size = max_wal_size,
-	    .max_threads = max_threads,
-	};
+	// Parse FDP mapping
+	std::unordered_map<string, uint8_t> fdp_mapping;
+	auto pairs = StringUtil::Split(fdp_mapping_str, ",");
+	for (const auto &pair : pairs) {
+		auto kv = StringUtil::Split(pair, ":");
+		if (kv.size() == 2) {
+			fdp_mapping[kv[0]] = (uint8_t)std::stoul(kv[1]);
+		}
+	}
+
+	return NvmeConfig {.device_path = device,
+	                   .backend = backend,
+	                   .meta = meta,
+	                   .max_temp_size = max_temp_size,
+	                   .max_wal_size = max_wal_size,
+	                   .max_threads = max_threads,
+	                   .fdp_mapping = fdp_mapping};
 }
 
 string NvmeConfigManager::SanatizeBackend(const string &backend) {

--- a/src/nvmefs_extension.cpp
+++ b/src/nvmefs_extension.cpp
@@ -58,8 +58,6 @@ static void AddConfig(DatabaseInstance &instance) {
 
 	DBConfig &config = DBConfig::GetConfig(instance);
 
-	config.AddExtensionOption
-
 	NvmeConfigManager::RegisterConfigFunctions(instance);
 	NvmeConfig nvmeConfig = NvmeConfigManager::LoadConfig(instance);
 

--- a/src/nvmefs_extension.cpp
+++ b/src/nvmefs_extension.cpp
@@ -58,6 +58,8 @@ static void AddConfig(DatabaseInstance &instance) {
 
 	DBConfig &config = DBConfig::GetConfig(instance);
 
+	config.AddExtensionOption
+
 	NvmeConfigManager::RegisterConfigFunctions(instance);
 	NvmeConfig nvmeConfig = NvmeConfigManager::LoadConfig(instance);
 

--- a/src/nvmefs_extension.cpp
+++ b/src/nvmefs_extension.cpp
@@ -78,11 +78,71 @@ static void AddConfig(DatabaseInstance &instance) {
 	}
 }
 
+// From nvmefs.cpp
+extern std::atomic<uint64_t> nvmefs_total_spill_bytes;
+extern std::atomic<uint64_t> nvmefs_total_wal_bytes;
+extern std::atomic<uint64_t> nvmefs_current_wal_bytes;
+extern std::atomic<uint64_t> nvmefs_peak_wal_bytes;
+
+// From temporary_file_metadata_manager.cpp
+extern std::atomic<int64_t> nvmefs_active_temp_files;
+extern std::atomic<int64_t> nvmefs_peak_temp_files;
+
+// From nvmefs_temporary_block_manager.cpp
+extern std::atomic<uint64_t> nvmefs_active_temp_bytes;
+extern std::atomic<uint64_t> nvmefs_peak_temp_bytes;
+
+static void MetricsPrint(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->CastNoConst<ConfigPrintFunctionData>(); // Reusing your struct
+	if (data.finished)
+		return;
+
+	idx_t row_idx = 0;
+
+	output.SetValue(0, row_idx, Value("total_spill_bytes"));
+	output.SetValue(1, row_idx, Value::UBIGINT(nvmefs_total_spill_bytes.load()));
+	row_idx++;
+
+	output.SetValue(0, row_idx, Value("total_wal_bytes"));
+	output.SetValue(1, row_idx, Value::UBIGINT(nvmefs_total_wal_bytes.load()));
+	row_idx++;
+
+	output.SetValue(0, row_idx, Value("current_wal_bytes"));
+	output.SetValue(1, row_idx, Value::UBIGINT(nvmefs_current_wal_bytes.load()));
+	row_idx++;
+
+	output.SetValue(0, row_idx, Value("peak_wal_bytes"));
+	output.SetValue(1, row_idx, Value::UBIGINT(nvmefs_peak_wal_bytes.load()));
+	row_idx++;
+
+	output.SetValue(0, row_idx, Value("active_temp_files"));
+	output.SetValue(1, row_idx, Value::BIGINT(nvmefs_active_temp_files.load()));
+	row_idx++;
+
+	output.SetValue(0, row_idx, Value("peak_temp_files"));
+	output.SetValue(1, row_idx, Value::BIGINT(nvmefs_peak_temp_files.load()));
+	row_idx++;
+
+	output.SetValue(0, row_idx, Value("active_temp_bytes"));
+	output.SetValue(1, row_idx, Value::UBIGINT(nvmefs_active_temp_bytes.load()));
+	row_idx++;
+
+	output.SetValue(0, row_idx, Value("peak_temp_bytes"));
+	output.SetValue(1, row_idx, Value::UBIGINT(nvmefs_peak_temp_bytes.load()));
+	row_idx++;
+
+	output.SetCardinality(row_idx);
+	data.finished = true;
+}
+
 static void LoadInternal(DatabaseInstance &instance) {
 	AddConfig(instance);
 
 	TableFunction config_print_function("print_config", {}, ConfigPrint, ConfigPrintBind);
 	ExtensionUtil::RegisterFunction(instance, config_print_function);
+
+	TableFunction metrics_print_function("print_nvmefs_metrics", {}, MetricsPrint, ConfigPrintBind);
+	ExtensionUtil::RegisterFunction(instance, metrics_print_function);
 }
 
 void NvmefsExtension::Load(DuckDB &db) {

--- a/src/nvmefs_temporary_block_manager.cpp
+++ b/src/nvmefs_temporary_block_manager.cpp
@@ -1,7 +1,12 @@
 #include "nvmefs_temporary_block_manager.hpp"
 #include <optional>
+#include <atomic>
 
 namespace duckdb {
+
+std::atomic<uint64_t> nvmefs_active_temp_bytes {0};
+std::atomic<uint64_t> nvmefs_peak_temp_bytes {0};
+
 TemporaryBlock::TemporaryBlock(idx_t start_lba, idx_t lba_amount)
     : start_lba(start_lba), lba_amount(lba_amount), is_free(false) {
 
@@ -91,6 +96,13 @@ TemporaryBlock *NvmeTemporaryBlockManager::AllocateBlock(idx_t lba_amount) {
 	// Return the block
 	block->is_free = false; // Mark the block as used
 
+	uint64_t added_bytes = lba_amount * 4096; // Assuming 4K LBA
+	uint64_t current_bytes = nvmefs_active_temp_bytes.fetch_add(added_bytes) + added_bytes;
+
+	uint64_t peak = nvmefs_peak_temp_bytes.load();
+	while (current_bytes > peak && !nvmefs_peak_temp_bytes.compare_exchange_weak(peak, current_bytes)) {
+	}
+
 	// auto end_time = std::chrono::high_resolution_clock::now();
 	// auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
 	// // Print the duration
@@ -155,6 +167,7 @@ void NvmeTemporaryBlockManager::FreeBlock(TemporaryBlock *block) {
 
 	// Mark the block as free
 	block->is_free = true;
+	nvmefs_active_temp_bytes.fetch_sub(block->lba_amount * 4096); // Assuming 4K LBA
 
 	// Coalesce the free blocks
 	CoalesceFreeBlocks(block);

--- a/src/temporary_file_metadata_manager.cpp
+++ b/src/temporary_file_metadata_manager.cpp
@@ -1,6 +1,11 @@
 #include "temporary_file_metadata_manager.hpp"
+#include <iostream>
+#include <atomic>
 
 namespace duckdb {
+
+std::atomic<int64_t> nvmefs_active_temp_files {0};
+std::atomic<int64_t> nvmefs_peak_temp_files {0};
 
 inline idx_t GetBufferSize(const string buffer_size_string) {
 
@@ -75,11 +80,18 @@ const TempFileMetadata *TemporaryFileMetadataManager::GetOrCreateFile(const stri
 	//    tfmeta->file_index);
 	auto [entry, is_new] = file_to_temp_meta.emplace(filename, std::move(tfmeta));
 
+	if (is_new) {
+		int64_t current = ++nvmefs_active_temp_files;
+		int64_t peak = nvmefs_peak_temp_files.load();
+		while (current > peak && !nvmefs_peak_temp_files.compare_exchange_weak(peak, current)) {
+		}
+	}
+
 	return file_to_temp_meta[filename].get();
 }
 
 void TemporaryFileMetadataManager::CreateFile(const string &filename) {
-
+	// duckdb::Printer::Print(StringUtil::Format("Creating file: %s", filename));
 	GetOrCreateFile(filename);
 }
 
@@ -173,6 +185,7 @@ void TemporaryFileMetadataManager::DeleteFile(const string &filename) {
 	}
 
 	file_to_temp_meta.erase(filename);
+	nvmefs_active_temp_files--;
 }
 
 bool TemporaryFileMetadataManager::FileExists(const string &filename) {
@@ -208,6 +221,7 @@ void TemporaryFileMetadataManager::Clear() {
 	}
 
 	file_to_temp_meta.clear();
+	nvmefs_active_temp_files.store(0);
 }
 
 idx_t TemporaryFileMetadataManager::GetSeekBound(const string &filename) {


### PR DESCRIPTION
This pull requests adds an FDP mapping to the DuckDB secret, allowing the user to specify which files are directed to which RUHs.
Additionally, it adds metrics for tracking temporary file spilling and WAL appending, as well as asks the user for confirmation when deallocating the NVMe drive though DSM