### PR TITLE
DSM on temporary file truncate delete

### DIFF
--- a/src/include/nvme_device.hpp
+++ b/src/include/nvme_device.hpp
@@ -28,6 +28,7 @@ class NvmeDevice : public Device {
 	friend class NvmeSyncIOEngine;
 	friend class NvmeAsyncThreadPollingIOEngine;
 	friend class NvmeAsynPrefetchIOEngine;
+	friend class TemporaryFileStrategy;
 
 public:
 	NvmeDevice(const NvmeConfig &config);

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -111,6 +111,7 @@ private:
 	void InitializeMetadata(const string &filename);
 	unique_ptr<GlobalMetadata> ReadMetadata();
 	void WriteMetadata(GlobalMetadata &global);
+	NvmeDevice &GetNvmeDevice();
 
 private:
 	Allocator &allocator;

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -11,9 +11,9 @@ class TemporaryBlock {
 public:
 	/// @brief Constructor for TemporaryBlock
 	/// @param start_lba Start LBA of the block (inclusive)
-	/// @param lba_amount Number of LBAs in the block
-	TemporaryBlock(idx_t start_lba, idx_t lba_amount);
-	idx_t GetLBAAmount();
+	/// @param lba_count Number of LBAs in the block
+	TemporaryBlock(idx_t start_lba, idx_t lba_count);
+	idx_t GetLBACount();
 	idx_t GetStartLBA();
 	idx_t GetEndLBA();
 
@@ -21,7 +21,7 @@ public:
 
 private:
 	idx_t start_lba;
-	idx_t lba_amount;
+	idx_t lba_count;
 	bool is_free;
 
 	// The next and previous blocks in the linked list
@@ -38,18 +38,18 @@ public:
 	NvmeTemporaryBlockManager(idx_t allocated_lba_start, idx_t allocated_lba_end);
 
 public:
-	TemporaryBlock *AllocateBlock(idx_t lba_amount);
+	TemporaryBlock *AllocateBlock(idx_t lba_count);
 	void FreeBlock(TemporaryBlock *block);
 
 private:
-	uint8_t GetFreeListIndex(idx_t lba_amount);
+	uint8_t GetFreeListIndex(idx_t lba_count);
 
 	/// @brief Splits a block into two blocks. The first block will be the requested size and the second block will be
 	/// the remaining size.
 	/// @param block The block to split
-	/// @param lba_amount Amount that the new splitted block should have
+	/// @param lba_count Amount that the new splitted block should have
 	/// @return The splitted block
-	TemporaryBlock *SplitBlock(TemporaryBlock *block, idx_t lba_amount);
+	TemporaryBlock *SplitBlock(TemporaryBlock *block, idx_t lba_count);
 	void PrintBlocks(TemporaryBlock *block);
 	void PrintBlocksBackwards(TemporaryBlock *block);
 

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -13,7 +13,7 @@ public:
 	/// @param start_lba Start LBA of the block (inclusive)
 	/// @param lba_amount Number of LBAs in the block
 	TemporaryBlock(idx_t start_lba, idx_t lba_amount);
-	idx_t GetSizeInBytes();
+	idx_t GetLBAAmount();
 	idx_t GetStartLBA();
 	idx_t GetEndLBA();
 

--- a/src/include/strategies/file_strategy_factory.hpp
+++ b/src/include/strategies/file_strategy_factory.hpp
@@ -12,6 +12,7 @@ class FileStrategyFactory {
 public:
 	static FileMetadataStrategy *GetStrategy(const string &filename, GlobalMetadata *metadata,
 	                                         atomic<idx_t> &db_location, atomic<idx_t> &wal_location,
+	                                         NvmeDevice &device,
 	                                         unique_ptr<TemporaryFileMetadataManager> &temp_manager) {
 		NvmeFileType type = NvmePathHandler::GetFileType(filename);
 
@@ -21,7 +22,7 @@ public:
 		case NvmeFileType::WAL:
 			return new WALFileStrategy(metadata, wal_location);
 		case NvmeFileType::TEMPORARY:
-			return new TemporaryFileStrategy(metadata, temp_manager);
+			return new TemporaryFileStrategy(metadata, device, temp_manager);
 		default:
 			throw InvalidInputException("Unknown file type for: %s", filename);
 		}

--- a/src/include/strategies/temporary_file_strategy.hpp
+++ b/src/include/strategies/temporary_file_strategy.hpp
@@ -10,8 +10,9 @@ struct GlobalMetadata;
 
 class TemporaryFileStrategy : public FileMetadataStrategy {
 public:
-	TemporaryFileStrategy(GlobalMetadata *metadata, unique_ptr<TemporaryFileMetadataManager> &temp_manager)
-	    : metadata(metadata), temp_manager(temp_manager) {
+	TemporaryFileStrategy(GlobalMetadata *metadata, NvmeDevice &device,
+	                      unique_ptr<TemporaryFileMetadataManager> &temp_manager)
+	    : metadata(metadata), device(device), temp_manager(temp_manager) {
 	}
 
 	idx_t GetLBA(const string &filename, idx_t nr_bytes, idx_t location, idx_t nr_lbas,
@@ -28,11 +29,11 @@ public:
 	}
 
 	void Truncate(const string &filename, idx_t new_size) override {
-		temp_manager->TruncateFile(filename, new_size);
+		temp_manager->TruncateFile(filename, new_size, device.device);
 	}
 
 	void RemoveFile(const string &filename) override {
-		temp_manager->DeleteFile(filename);
+		temp_manager->DeleteFile(filename, device.device);
 	}
 
 	idx_t GetSeekBound(const string &filename, const DeviceGeometry &geo) override {
@@ -78,6 +79,7 @@ public:
 
 private:
 	GlobalMetadata *metadata;
+	NvmeDevice &device;
 	unique_ptr<TemporaryFileMetadataManager> &temp_manager;
 };
 

--- a/src/include/temporary_file_metadata_manager.hpp
+++ b/src/include/temporary_file_metadata_manager.hpp
@@ -28,7 +28,7 @@ class TemporaryFileMetadataManager {
 public:
 	TemporaryFileMetadataManager(idx_t start_lba, idx_t end_lba, idx_t lba_size)
 	    : block_manager(make_uniq<NvmeTemporaryBlockManager>(start_lba, end_lba)), lba_size(lba_size),
-	      lba_amount(end_lba - start_lba) {
+	      lba_count(end_lba - start_lba) {
 	}
 
 	void CreateFile(const string &filename);
@@ -59,7 +59,7 @@ private:
 	void DSMBlock(TemporaryBlock *block, xnvme_dev *dev);
 
 	idx_t lba_size;
-	idx_t lba_amount;
+	idx_t lba_count;
 	unique_ptr<NvmeTemporaryBlockManager> block_manager;
 	map<string, unique_ptr<TempFileMetadata>> file_to_temp_meta;
 	static inline boost::shared_mutex temp_mutex;

--- a/src/include/temporary_file_metadata_manager.hpp
+++ b/src/include/temporary_file_metadata_manager.hpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <boost/thread/shared_mutex.hpp> // sudo apt-get install libboost-all-dev
 #include <boost/thread/locks.hpp>
+#include <libxnvme.h>
 #include <shared_mutex>
 
 namespace duckdb {
@@ -34,9 +35,9 @@ public:
 
 	idx_t GetLBA(const string &filename, idx_t location, idx_t nr_lbas);
 
-	void TruncateFile(const string &filename, idx_t new_size);
+	void TruncateFile(const string &filename, idx_t new_size, xnvme_dev *dev);
 
-	void DeleteFile(const string &filename);
+	void DeleteFile(const string &filename, xnvme_dev *dev);
 
 	void MoveLBALocation(const string &filename, idx_t lba_location);
 
@@ -55,6 +56,8 @@ public:
 	const TempFileMetadata *GetOrCreateFile(const string &filename);
 
 private:
+	void DSMBlock(TemporaryBlock *block, xnvme_dev *dev);
+
 	idx_t lba_size;
 	idx_t lba_amount;
 	unique_ptr<NvmeTemporaryBlockManager> block_manager;

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -110,8 +110,9 @@ unique_ptr<FileHandle> NvmeFileSystem::OpenFile(const string &path, FileOpenFlag
 		throw InternalException("Metadata uninitialized after loading attempt");
 	}
 
-	unique_ptr<FileMetadataStrategy> strategy(
-	    FileStrategyFactory::GetStrategy(path, metadata.get(), db_location, wal_location, temp_meta_manager));
+	auto &nvme_device = GetNvmeDevice();
+	unique_ptr<FileMetadataStrategy> strategy(FileStrategyFactory::GetStrategy(
+	    path, metadata.get(), db_location, wal_location, nvme_device, temp_meta_manager));
 
 	if (flags.CreateFileIfNotExists() && NvmePathHandler::GetFileType(path) == NvmeFileType::TEMPORARY) {
 		strategy->CreateFile(path);
@@ -205,8 +206,9 @@ bool NvmeFileSystem::FileExists(const string &filename, optional_ptr<FileOpener>
 		return false;
 	}
 
-	unique_ptr<FileMetadataStrategy> strategy(
-	    FileStrategyFactory::GetStrategy(filename, metadata.get(), db_location, wal_location, temp_meta_manager));
+	auto &nvme_device = GetNvmeDevice();
+	unique_ptr<FileMetadataStrategy> strategy(FileStrategyFactory::GetStrategy(
+	    filename, metadata.get(), db_location, wal_location, nvme_device, temp_meta_manager));
 
 	return strategy->FileExists(filename);
 }
@@ -260,7 +262,8 @@ void NvmeFileSystem::RemoveDirectory(const string &directory, optional_ptr<FileO
 	NvmeFileType type = NvmePathHandler::GetFileType(directory);
 
 	if (type == NvmeFileType::TEMPORARY) {
-		TemporaryFileStrategy temp_strategy(metadata.get(), temp_meta_manager);
+		auto &nvme_device = GetNvmeDevice();
+		TemporaryFileStrategy temp_strategy(metadata.get(), nvme_device, temp_meta_manager);
 		temp_strategy.ClearAll();
 	} else {
 		throw IOException("Cannot delete unknown directory");
@@ -280,8 +283,9 @@ void NvmeFileSystem::CreateDirectoriesRecursive(const string &path, optional_ptr
 }
 
 void NvmeFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
-	unique_ptr<FileMetadataStrategy> strategy(
-	    FileStrategyFactory::GetStrategy(filename, metadata.get(), db_location, wal_location, temp_meta_manager));
+	auto &nvme_device = GetNvmeDevice();
+	unique_ptr<FileMetadataStrategy> strategy(FileStrategyFactory::GetStrategy(
+	    filename, metadata.get(), db_location, wal_location, nvme_device, temp_meta_manager));
 
 	strategy->RemoveFile(filename);
 }
@@ -303,8 +307,9 @@ void NvmeFileSystem::Seek(FileHandle &handle, idx_t location) {
 
 	D_ASSERT(location % geo.lba_size == 0);
 
+	auto &nvme_device = GetNvmeDevice();
 	unique_ptr<FileMetadataStrategy> strategy(FileStrategyFactory::GetStrategy(
-	    nvme_handle.path, metadata.get(), db_location, wal_location, temp_meta_manager));
+	    nvme_handle.path, metadata.get(), db_location, wal_location, nvme_device, temp_meta_manager));
 
 	idx_t max_seek_bound = strategy->GetSeekBound(nvme_handle.path, geo);
 
@@ -340,7 +345,8 @@ bool NvmeFileSystem::ListFiles(const string &directory, const std::function<void
 		dir = true;
 	} else if (StringUtil::Equals(directory.data(), NvmePathHandler::TMP_DIR_PATH.data())) {
 		dir = true;
-		TemporaryFileStrategy temp_strategy(metadata.get(), temp_meta_manager);
+		auto &nvme_device = GetNvmeDevice();
+		TemporaryFileStrategy temp_strategy(metadata.get(), nvme_device, temp_meta_manager);
 		temp_strategy.ListFiles(directory, callback);
 	}
 	return dir;
@@ -354,7 +360,8 @@ optional_idx NvmeFileSystem::GetAvailableDiskSpace(const string &path) {
 	if (StringUtil::Equals(path.data(), NvmePathHandler::PATH_PREFIX.data())) {
 		DatabaseFileStrategy db_strategy(metadata.get(), db_location);
 		WALFileStrategy wal_strategy(metadata.get(), wal_location);
-		TemporaryFileStrategy temp_strategy(metadata.get(), temp_meta_manager);
+		auto &nvme_device = GetNvmeDevice();
+		TemporaryFileStrategy temp_strategy(metadata.get(), nvme_device, temp_meta_manager);
 
 		optional_idx db_avail = db_strategy.GetAvailableSpace(geo);
 		optional_idx wal_avail = wal_strategy.GetAvailableSpace(geo);
@@ -362,7 +369,8 @@ optional_idx NvmeFileSystem::GetAvailableDiskSpace(const string &path) {
 
 		remaining = db_avail.GetIndex() + wal_avail.GetIndex() + temp_avail.GetIndex();
 	} else if (StringUtil::Equals(path.data(), NvmePathHandler::TMP_DIR_PATH.data())) {
-		TemporaryFileStrategy temp_strategy(metadata.get(), temp_meta_manager);
+		auto &nvme_device = GetNvmeDevice();
+		TemporaryFileStrategy temp_strategy(metadata.get(), nvme_device, temp_meta_manager);
 		remaining = temp_strategy.GetAvailableSpace(geo);
 	}
 	return remaining;
@@ -486,6 +494,16 @@ void NvmeFileSystem::WriteMetadata(GlobalMetadata &global) {
 	device->Write(buffer, *cmd_ctx);
 
 	allocator.FreeData(buffer, bytes_to_write);
+}
+
+NvmeDevice &NvmeFileSystem::GetNvmeDevice() {
+	NvmeDevice *raw_nvme_device = dynamic_cast<NvmeDevice *>(device.get());
+
+	if (raw_nvme_device) {
+		return *raw_nvme_device;
+	} else {
+		throw InternalException("Value of field device is not of type NvmeDevice");
+	}
 }
 
 } // namespace duckdb

--- a/src/nvmefs_temporary_block_manager.cpp
+++ b/src/nvmefs_temporary_block_manager.cpp
@@ -9,15 +9,14 @@ std::atomic<uint64_t> nvmefs_peak_temp_bytes {0};
 
 TemporaryBlock::TemporaryBlock(idx_t start_lba, idx_t lba_amount)
     : start_lba(start_lba), lba_amount(lba_amount), is_free(false) {
-
 	next_block = nullptr;
 	previous_block = nullptr;
 	next_free_block = nullptr;
 	previous_free_block = nullptr;
 }
 
-idx_t TemporaryBlock::GetSizeInBytes() {
-	return lba_amount * 4096; // TODO: Get the LBA size from the device
+idx_t TemporaryBlock::GetLBAAmount() {
+	return lba_amount;
 }
 
 idx_t TemporaryBlock::GetStartLBA() {
@@ -121,7 +120,6 @@ void NvmeTemporaryBlockManager::PrintBlocks(TemporaryBlock *block) {
 	printf("-------\n");
 }
 void NvmeTemporaryBlockManager::PrintBlocksBackwards(TemporaryBlock *block) {
-
 	printf("-------\n");
 	while (block != nullptr) {
 		printf("Block start lba %llu end lba %llu, is_free %d\n", block->GetStartLBA(), block->GetEndLBA(),
@@ -162,7 +160,6 @@ TemporaryBlock *NvmeTemporaryBlockManager::SplitBlock(TemporaryBlock *block, idx
 }
 
 void NvmeTemporaryBlockManager::FreeBlock(TemporaryBlock *block) {
-
 	// auto start_time = std::chrono::high_resolution_clock::now();
 
 	// Mark the block as free
@@ -224,7 +221,6 @@ TemporaryBlock *NvmeTemporaryBlockManager::PopFreeBlock(uint8_t free_list_index)
 }
 
 void NvmeTemporaryBlockManager::RemoveFreeBlock(TemporaryBlock *block) {
-
 	if (block->next_free_block != nullptr) {
 		block->next_free_block->previous_free_block = block->previous_free_block;
 	}
@@ -249,12 +245,10 @@ void NvmeTemporaryBlockManager::CoalesceFreeBlocks(TemporaryBlock *block) {
 	// Check if the previous block is free
 	if ((block->previous_block != nullptr && block->previous_block->IsFree()) &&
 	    (block->next_block != nullptr && block->next_block->IsFree())) {
-
 		block->start_lba = block->previous_block->start_lba; // Set the start lba to the previous blocks start lba
 		block->lba_amount += block->previous_block->lba_amount + block->next_block->lba_amount;
 
 		if (block->previous_block->previous_block != nullptr) {
-
 			unique_ptr<TemporaryBlock> old_left_block = move(block->previous_block->previous_block->next_block);
 
 			block->previous_block->previous_block->next_block =

--- a/src/nvmefs_temporary_block_manager.cpp
+++ b/src/nvmefs_temporary_block_manager.cpp
@@ -7,16 +7,16 @@ namespace duckdb {
 std::atomic<uint64_t> nvmefs_active_temp_bytes {0};
 std::atomic<uint64_t> nvmefs_peak_temp_bytes {0};
 
-TemporaryBlock::TemporaryBlock(idx_t start_lba, idx_t lba_amount)
-    : start_lba(start_lba), lba_amount(lba_amount), is_free(false) {
+TemporaryBlock::TemporaryBlock(idx_t start_lba, idx_t lba_count)
+    : start_lba(start_lba), lba_count(lba_count), is_free(false) {
 	next_block = nullptr;
 	previous_block = nullptr;
 	next_free_block = nullptr;
 	previous_free_block = nullptr;
 }
 
-idx_t TemporaryBlock::GetLBAAmount() {
-	return lba_amount;
+idx_t TemporaryBlock::GetLBACount() {
+	return lba_count;
 }
 
 idx_t TemporaryBlock::GetStartLBA() {
@@ -24,7 +24,7 @@ idx_t TemporaryBlock::GetStartLBA() {
 }
 
 idx_t TemporaryBlock::GetEndLBA() {
-	return start_lba + lba_amount - 1;
+	return start_lba + lba_count - 1;
 }
 
 bool TemporaryBlock::IsFree() {
@@ -42,33 +42,33 @@ NvmeTemporaryBlockManager::NvmeTemporaryBlockManager(idx_t allocated_lba_start, 
 	blocks->is_free = true;        // Mark the block as free
 }
 
-uint8_t NvmeTemporaryBlockManager::GetFreeListIndex(idx_t lba_amount) {
+uint8_t NvmeTemporaryBlockManager::GetFreeListIndex(idx_t lba_count) {
 	// Get the index of the free list for the given size
-	if (lba_amount <= 8) {
+	if (lba_count <= 8) {
 		return 0;
-	} else if (lba_amount <= 16) {
+	} else if (lba_count <= 16) {
 		return 1;
-	} else if (lba_amount <= 24) {
+	} else if (lba_count <= 24) {
 		return 2;
-	} else if (lba_amount <= 32) {
+	} else if (lba_count <= 32) {
 		return 3;
-	} else if (lba_amount <= 40) {
+	} else if (lba_count <= 40) {
 		return 4;
-	} else if (lba_amount <= 48) {
+	} else if (lba_count <= 48) {
 		return 5;
-	} else if (lba_amount <= 56) {
+	} else if (lba_count <= 56) {
 		return 6;
-	} else if (lba_amount <= 64) {
+	} else if (lba_count <= 64) {
 		return 7;
 	}
 
 	return 7;
 }
 
-TemporaryBlock *NvmeTemporaryBlockManager::AllocateBlock(idx_t lba_amount) {
+TemporaryBlock *NvmeTemporaryBlockManager::AllocateBlock(idx_t lba_count) {
 	// auto start_time = std::chrono::high_resolution_clock::now();
 	// Get the free list index for the given size
-	uint8_t free_list_index = GetFreeListIndex(lba_amount);
+	uint8_t free_list_index = GetFreeListIndex(lba_count);
 
 	TemporaryBlock *block = nullptr;
 
@@ -80,8 +80,8 @@ TemporaryBlock *NvmeTemporaryBlockManager::AllocateBlock(idx_t lba_amount) {
 
 			// Check if the block is large enough
 			// Split the block if it is larger than the requested size
-			if (block->lba_amount > lba_amount) {
-				block = SplitBlock(block, lba_amount);
+			if (block->lba_count > lba_count) {
+				block = SplitBlock(block, lba_count);
 			}
 
 			break; // If we are in here we have found a block
@@ -95,7 +95,7 @@ TemporaryBlock *NvmeTemporaryBlockManager::AllocateBlock(idx_t lba_amount) {
 	// Return the block
 	block->is_free = false; // Mark the block as used
 
-	uint64_t added_bytes = lba_amount * 4096; // Assuming 4K LBA
+	uint64_t added_bytes = lba_count * 4096; // Assuming 4K LBA
 	uint64_t current_bytes = nvmefs_active_temp_bytes.fetch_add(added_bytes) + added_bytes;
 
 	uint64_t peak = nvmefs_peak_temp_bytes.load();
@@ -129,15 +129,15 @@ void NvmeTemporaryBlockManager::PrintBlocksBackwards(TemporaryBlock *block) {
 	printf("-------\n");
 }
 
-TemporaryBlock *NvmeTemporaryBlockManager::SplitBlock(TemporaryBlock *block, idx_t lba_amount) {
+TemporaryBlock *NvmeTemporaryBlockManager::SplitBlock(TemporaryBlock *block, idx_t lba_count) {
 	// Create a new block with the remaining size
-	unique_ptr<TemporaryBlock> new_block = make_uniq<TemporaryBlock>(block->start_lba, lba_amount);
+	unique_ptr<TemporaryBlock> new_block = make_uniq<TemporaryBlock>(block->start_lba, lba_count);
 	TemporaryBlock *new_block_ptr = new_block.get();
 
 	// Update the original block size
 	idx_t endLba = block->GetEndLBA();
-	block->start_lba += lba_amount;
-	block->lba_amount -= lba_amount;
+	block->start_lba += lba_count;
+	block->lba_count -= lba_count;
 
 	// Add the new block to the free list
 	if (new_block->GetStartLBA() != allocated_start_lba) {
@@ -164,7 +164,7 @@ void NvmeTemporaryBlockManager::FreeBlock(TemporaryBlock *block) {
 
 	// Mark the block as free
 	block->is_free = true;
-	nvmefs_active_temp_bytes.fetch_sub(block->lba_amount * 4096); // Assuming 4K LBA
+	nvmefs_active_temp_bytes.fetch_sub(block->lba_count * 4096); // Assuming 4K LBA
 
 	// Coalesce the free blocks
 	CoalesceFreeBlocks(block);
@@ -184,7 +184,7 @@ void NvmeTemporaryBlockManager::PushFreeBlock(TemporaryBlock *block) {
 	D_ASSERT(block->previous_free_block == nullptr);
 
 	// Add the block to the free list
-	uint8_t free_list_index = GetFreeListIndex(block->lba_amount);
+	uint8_t free_list_index = GetFreeListIndex(block->lba_count);
 
 	TemporaryBlock *previous_top_block = blocks_free[free_list_index];
 	if (previous_top_block != nullptr) {
@@ -226,7 +226,7 @@ void NvmeTemporaryBlockManager::RemoveFreeBlock(TemporaryBlock *block) {
 	}
 
 	if (block->previous_free_block == nullptr) {
-		uint8_t free_list_index = GetFreeListIndex(block->lba_amount);
+		uint8_t free_list_index = GetFreeListIndex(block->lba_count);
 
 		blocks_free[free_list_index] = block->next_free_block;
 		if (blocks_free[free_list_index] != nullptr) {
@@ -246,7 +246,7 @@ void NvmeTemporaryBlockManager::CoalesceFreeBlocks(TemporaryBlock *block) {
 	if ((block->previous_block != nullptr && block->previous_block->IsFree()) &&
 	    (block->next_block != nullptr && block->next_block->IsFree())) {
 		block->start_lba = block->previous_block->start_lba; // Set the start lba to the previous blocks start lba
-		block->lba_amount += block->previous_block->lba_amount + block->next_block->lba_amount;
+		block->lba_count += block->previous_block->lba_count + block->next_block->lba_count;
 
 		if (block->previous_block->previous_block != nullptr) {
 			unique_ptr<TemporaryBlock> old_left_block = move(block->previous_block->previous_block->next_block);
@@ -277,7 +277,7 @@ void NvmeTemporaryBlockManager::CoalesceFreeBlocks(TemporaryBlock *block) {
 
 	} else if (block->previous_block != nullptr && block->previous_block->IsFree()) {
 		block->start_lba = block->previous_block->start_lba; // Set the start lba to the previous blocks start lba
-		block->lba_amount += block->previous_block->lba_amount;
+		block->lba_count += block->previous_block->lba_count;
 
 		if (block->previous_block->previous_block != nullptr) {
 			unique_ptr<TemporaryBlock> old_left_block = move(block->previous_block->previous_block->next_block);
@@ -295,7 +295,7 @@ void NvmeTemporaryBlockManager::CoalesceFreeBlocks(TemporaryBlock *block) {
 			blocks->previous_block = nullptr; // Set the previous block to null
 		}
 	} else if (block->next_block != nullptr && block->next_block->IsFree()) {
-		block->lba_amount += block->next_block->lba_amount;
+		block->lba_count += block->next_block->lba_count;
 
 		unique_ptr<TemporaryBlock> old_right_block = move(block->next_block);
 

--- a/src/temporary_file_metadata_manager.cpp
+++ b/src/temporary_file_metadata_manager.cpp
@@ -1,6 +1,9 @@
 #include "temporary_file_metadata_manager.hpp"
+#include "nvmefs_temporary_block_manager.hpp"
 #include <iostream>
 #include <atomic>
+#include <libxnvme.h>
+#include <libxnvme_nvm.h>
 
 namespace duckdb {
 
@@ -8,7 +11,6 @@ std::atomic<int64_t> nvmefs_active_temp_files {0};
 std::atomic<int64_t> nvmefs_peak_temp_files {0};
 
 inline idx_t GetBufferSize(const string buffer_size_string) {
-
 	if (!buffer_size_string.compare("S32K")) {
 		return 32768;
 	} else if (!buffer_size_string.compare("S64K")) {
@@ -31,7 +33,6 @@ inline idx_t GetBufferSize(const string buffer_size_string) {
 }
 
 inline unique_ptr<TempFileMetadata> CreateTempFileMetadata(const string &filename) {
-
 	unique_ptr<TempFileMetadata> tfmeta = make_uniq<TempFileMetadata>();
 	tfmeta->is_active.store(true);
 
@@ -61,7 +62,6 @@ inline unique_ptr<TempFileMetadata> CreateTempFileMetadata(const string &filenam
 }
 
 const TempFileMetadata *TemporaryFileMetadataManager::GetOrCreateFile(const string &filename) {
-
 	// Lock the shared mutex for writing
 	{
 		boost::shared_lock<boost::shared_mutex> alloc_lock(temp_mutex);
@@ -109,7 +109,6 @@ idx_t TemporaryFileMetadataManager::GetLBA(const string &filename, idx_t locatio
 		}
 
 		if (tfmeta->block_map.count(block_index)) {
-
 			return tfmeta->block_map[block_index]->GetStartLBA();
 		}
 	}
@@ -153,7 +152,7 @@ void TemporaryFileMetadataManager::MoveLBALocation(const string &filename, idx_t
 	// printf("MoveLBALocation %s, location %d\n", filename.c_str(), lba_location);
 }
 
-void TemporaryFileMetadataManager::TruncateFile(const string &filename, idx_t new_size) {
+void TemporaryFileMetadataManager::TruncateFile(const string &filename, idx_t new_size, xnvme_dev *dev) {
 	boost::unique_lock<boost::shared_mutex> lock(temp_mutex);
 
 	TempFileMetadata *tfmeta = file_to_temp_meta[filename].get();
@@ -168,19 +167,22 @@ void TemporaryFileMetadataManager::TruncateFile(const string &filename, idx_t ne
 		TemporaryBlock *block = tfmeta->block_map[block_index];
 		block_manager->FreeBlock(block);
 		tfmeta->block_map.erase(block_index);
+		DSMBlock(block, dev);
 	}
 
 	// file_to_temp_meta[nvme_handle.path] = tfmeta;
 }
 
-void TemporaryFileMetadataManager::DeleteFile(const string &filename) {
+void TemporaryFileMetadataManager::DeleteFile(const string &filename, xnvme_dev *dev) {
 	boost::unique_lock<boost::shared_mutex> lock(temp_mutex);
 
 	TempFileMetadata *tfmeta = file_to_temp_meta[filename].get();
 	{
 		boost::unique_lock<boost::shared_mutex> file_lock(tfmeta->file_mutex);
 		for (const auto &kv : tfmeta->block_map) {
-			block_manager->FreeBlock(kv.second);
+			TemporaryBlock *block = kv.second;
+			block_manager->FreeBlock(block);
+			DSMBlock(block, dev);
 		}
 	}
 
@@ -256,6 +258,17 @@ void TemporaryFileMetadataManager::ListFiles(const string &directory,
 	for (const auto &kv : file_to_temp_meta) {
 		callback(StringUtil::GetFileName(kv.first), false);
 	}
+}
+
+void TemporaryFileMetadataManager::DSMBlock(TemporaryBlock *block, xnvme_dev *dev) {
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	uint32_t nsid = xnvme_dev_get_nsid(dev);
+	struct xnvme_spec_dsm_range range = {
+	    .cattr = 0,
+	    .llb = static_cast<uint32_t>(block->GetLBAAmount()),
+	    .slba = block->GetStartLBA(),
+	};
+	xnvme_nvm_dsm(&ctx, nsid, &range, 0, true, false, false);
 }
 
 } // namespace duckdb

--- a/src/temporary_file_metadata_manager.cpp
+++ b/src/temporary_file_metadata_manager.cpp
@@ -265,7 +265,7 @@ void TemporaryFileMetadataManager::DSMBlock(TemporaryBlock *block, xnvme_dev *de
 	uint32_t nsid = xnvme_dev_get_nsid(dev);
 	struct xnvme_spec_dsm_range range = {
 	    .cattr = 0,
-	    .llb = static_cast<uint32_t>(block->GetLBAAmount()),
+	    .llb = static_cast<uint32_t>(block->GetLBACount()),
 	    .slba = block->GetStartLBA(),
 	};
 	xnvme_nvm_dsm(&ctx, nsid, &range, 0, true, false, false);

--- a/test/gtest/test_nvmefs_proxy.cpp
+++ b/test/gtest/test_nvmefs_proxy.cpp
@@ -21,7 +21,6 @@ protected:
 };
 
 class DiskInteractionTest : public testing::Test {
-
 protected:
 	DiskInteractionTest() {
 		// Set up the test environment
@@ -362,7 +361,6 @@ TEST_F(DiskInteractionTest, OpenFileProducesCorrectFileHandle) {
 }
 
 TEST_F(DiskInteractionTest, WriteAndReadData) {
-
 	// Create a file
 	string file_path = "nvmefs://test.db";
 	unique_ptr<FileHandle> file =
@@ -384,7 +382,6 @@ TEST_F(DiskInteractionTest, WriteAndReadData) {
 }
 
 TEST_F(DiskInteractionTest, WriteAndReadDataDoesNotOverlapOtherCategories) {
-
 	// Create a file
 	string file_path = "nvmefs://test.db";
 	string wal_file_path = "nvmefs://test.db.wal";
@@ -439,7 +436,6 @@ TEST_F(DiskInteractionTest, WriteAndReadDataDoesNotOverlapOtherCategories) {
 
 // TODO: Make this parameterized to test different byte offsets whithin different blocks
 TEST_F(DiskInteractionTest, WriteAndReadDataWithinBlock) {
-
 	// Create a file
 	string file_path = "nvmefs://test.db";
 	unique_ptr<FileHandle> file =
@@ -461,7 +457,6 @@ TEST_F(DiskInteractionTest, WriteAndReadDataWithinBlock) {
 }
 
 TEST_F(DiskInteractionTest, WriteAndReadDataWithSeek) {
-
 	// Create a file
 	string file_path = "nvmefs://test.db";
 	unique_ptr<FileHandle> file =
@@ -510,7 +505,6 @@ TEST_F(DiskInteractionTest, SeekOutOfDBMetadataBounds) {
 }
 
 TEST_F(DiskInteractionTest, SeekOutOfWALMetadataBounds) {
-
 	const uint64_t max_lba = 261503;
 	// Ensure that metadata is created
 	file_system->OpenFile("nvmefs://test.db", FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ);
@@ -526,7 +520,6 @@ TEST_F(DiskInteractionTest, SeekOutOfWALMetadataBounds) {
 }
 
 TEST_F(DiskInteractionTest, SeekOutOfTmpMetadataBounds) {
-
 	file_system->OpenFile("nvmefs://test.db", FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ);
 
 	// Create a file
@@ -1001,19 +994,16 @@ protected:
 };
 
 TEST_F(BlockManagerTest, FirstAllocateBlock) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block = block_manager->AllocateBlock(8);
 
 	// Check that the block is allocated correctly
 	EXPECT_EQ(block->GetStartLBA(), 0);
 	EXPECT_EQ(block->GetEndLBA(), 7);
-	EXPECT_EQ(block->GetSizeInBytes(), 8 * 4096);
 	EXPECT_EQ(block->IsFree(), false);
 }
 
 TEST_F(BlockManagerTest, AllocateTwiceInARow) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block = block_manager->AllocateBlock(8);
 	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
@@ -1021,18 +1011,15 @@ TEST_F(BlockManagerTest, AllocateTwiceInARow) {
 	// Check that the block is allocated correctly
 	EXPECT_EQ(block->GetStartLBA(), 0);
 	EXPECT_EQ(block->GetEndLBA(), 7);
-	EXPECT_EQ(block->GetSizeInBytes(), 8 * 4096);
 	EXPECT_EQ(block->IsFree(), false);
 
 	EXPECT_EQ(block2->GetStartLBA(), 8);
 	EXPECT_EQ(block2->GetEndLBA(), 15);
-	EXPECT_EQ(block2->GetSizeInBytes(), 8 * 4096);
 	EXPECT_EQ(block2->IsFree(), false);
 	EXPECT_EQ(block->GetEndLBA() + 1, block2->GetStartLBA());
 }
 
 TEST_F(BlockManagerTest, AllocateFreeAndAllocateAgainYieldsSameBlock) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block = block_manager->AllocateBlock(8);
 
@@ -1047,13 +1034,11 @@ TEST_F(BlockManagerTest, AllocateFreeAndAllocateAgainYieldsSameBlock) {
 
 	EXPECT_EQ(block2->GetStartLBA(), start_lba);
 	EXPECT_EQ(block2->GetEndLBA(), end_lba);
-	EXPECT_EQ(block2->GetSizeInBytes(), size);
 	EXPECT_EQ(block2->IsFree(), is_free);
 }
 
 TEST_F(BlockManagerTest,
        AllocateSameSizeThreeTimesFreeTheMiddleAllocationAndAllocateALargerObjectYieldsBlockAfterBlock3) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block = block_manager->AllocateBlock(8);
 	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
@@ -1073,13 +1058,11 @@ TEST_F(BlockManagerTest,
 
 	EXPECT_EQ(block4->GetStartLBA(), block3->GetEndLBA() + 1);
 	EXPECT_EQ(block4->GetEndLBA(), block4->GetStartLBA() + 15);
-	EXPECT_EQ(block4->GetSizeInBytes(), 16 * 4096);
 	EXPECT_EQ(block4->IsFree(), false);
 }
 
 TEST_F(BlockManagerTest,
        AllocateFreeBlocksAndFreeSurroundingBlocksAndAllocateALargerBlockYieldsBlockThatStartsFromSameLocation) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block = block_manager->AllocateBlock(8);
 	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
@@ -1099,14 +1082,12 @@ TEST_F(BlockManagerTest,
 
 	EXPECT_EQ(block4->GetStartLBA(), 0);
 	EXPECT_EQ(block4->GetEndLBA(), 23);
-	EXPECT_EQ(block4->GetSizeInBytes(), 24 * 4096);
 	EXPECT_EQ(block4->IsFree(), false);
 }
 
 TEST_F(
     BlockManagerTest,
     AllocateBlocksAndFreeTheMiddleBlockToTriggerCoalescingToTheLeftAndAcquireANewBlockThatShouldStartFromTheSameLocation) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block = block_manager->AllocateBlock(8);
 	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
@@ -1126,12 +1107,10 @@ TEST_F(
 
 	EXPECT_EQ(block4->GetStartLBA(), 0);
 	EXPECT_EQ(block4->GetEndLBA(), 15);
-	EXPECT_EQ(block4->GetSizeInBytes(), 16 * 4096);
 	EXPECT_EQ(block4->IsFree(), false);
 }
 
 TEST_F(BlockManagerTest, FreelistRemoveOneAtATime) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block1 = block_manager->AllocateBlock(8);
 	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
@@ -1149,19 +1128,16 @@ TEST_F(BlockManagerTest, FreelistRemoveOneAtATime) {
 
 	EXPECT_EQ(block->GetStartLBA(), 24);
 	EXPECT_EQ(block->GetEndLBA(), 31);
-	EXPECT_EQ(block->GetSizeInBytes(), 8 * 4096);
 	EXPECT_EQ(block->IsFree(), false);
 
 	TemporaryBlock *block5 = block_manager->AllocateBlock(8);
 
 	EXPECT_EQ(block5->GetStartLBA(), 8);
 	EXPECT_EQ(block5->GetEndLBA(), 15);
-	EXPECT_EQ(block5->GetSizeInBytes(), 8 * 4096);
 	EXPECT_EQ(block5->IsFree(), false);
 }
 
 TEST_F(BlockManagerTest, FreelistCoalesceLeftAndRightInTheMiddle) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block1 = block_manager->AllocateBlock(8);
 	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
@@ -1186,18 +1162,15 @@ TEST_F(BlockManagerTest, FreelistCoalesceLeftAndRightInTheMiddle) {
 
 	EXPECT_EQ(block->GetStartLBA(), 32);
 	EXPECT_EQ(block->GetEndLBA(), 47);
-	EXPECT_EQ(block->GetSizeInBytes(), 16 * 4096);
 	EXPECT_EQ(block->IsFree(), false);
 
 	TemporaryBlock *block11 = block_manager->AllocateBlock(8);
 	EXPECT_EQ(block11->GetStartLBA(), 48);
 	EXPECT_EQ(block11->GetEndLBA(), 55);
-	EXPECT_EQ(block11->GetSizeInBytes(), 8 * 4096);
 	EXPECT_EQ(block11->IsFree(), false);
 }
 
 TEST_F(BlockManagerTest, FreelistCoalesceLeftInTheMiddleOfTheList) {
-
 	// Allocate a block of size 8
 	TemporaryBlock *block1 = block_manager->AllocateBlock(8);
 	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
@@ -1222,13 +1195,11 @@ TEST_F(BlockManagerTest, FreelistCoalesceLeftInTheMiddleOfTheList) {
 
 	EXPECT_EQ(block->GetStartLBA(), 32);
 	EXPECT_EQ(block->GetEndLBA(), 47);
-	EXPECT_EQ(block->GetSizeInBytes(), 16 * 4096);
 	EXPECT_EQ(block->IsFree(), false);
 
 	TemporaryBlock *block11 = block_manager->AllocateBlock(8);
 	EXPECT_EQ(block11->GetStartLBA(), 48);
 	EXPECT_EQ(block11->GetEndLBA(), 55);
-	EXPECT_EQ(block11->GetSizeInBytes(), 8 * 4096);
 	EXPECT_EQ(block11->IsFree(), false);
 }
 
@@ -1243,7 +1214,6 @@ protected:
 };
 
 TEST_F(TemporaryMetadataManagerTest, CreateFilesOfDifferentSizes) {
-
 	string tmp_file_path1 = StringUtil::Format("nvmefs:///tmp/duckdb_temp_storage_%s-%llu.tmp", "S32K", 0);
 	metadata_manager->CreateFile(tmp_file_path1);
 	auto file32 = metadata_manager->GetOrCreateFile(tmp_file_path1);


### PR DESCRIPTION
nvmefs never called DSM for temporary files that are removed from the map in the code. This PR makes sure that we DSM the LBAs that are unused, such that the SSD controller can perform garbage collection.